### PR TITLE
chore: upgrade cloudflare workers compatibility date

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ wasm-opt = false
 crate-type = ["cdylib"]
 
 [dependencies]
-worker = "0.0.18"
+worker = "0.4.2"
 tokio = { version = "1.28", features = ["io-util"] }
 pin-project = "1.1.0"
 futures-util = { version = "0.3.28", default-features = false }

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
-	"name": "workers-tunnel",
-	"version": "0.0.0",
-	"private": true,
-	"scripts": {
-		"deploy": "wrangler deploy",
-		"dev": "wrangler dev --local"
-	},
-	"devDependencies": {
-		"wrangler": "^2.13.0"
-	}
+  "name": "workers-tunnel",
+  "version": "0.0.0",
+  "private": true,
+  "scripts": {
+    "deploy": "wrangler deploy",
+    "dev": "wrangler dev --local"
+  },
+  "devDependencies": {
+    "wrangler": "3.83.0"
+  }
 }

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,6 +1,6 @@
 name = "workers-tunnel"
 main = "build/worker/shim.mjs"
-compatibility_date = "2023-03-22"
+compatibility_date = "2024-09-02"
 
 [build]
 command = "cargo install -q worker-build && worker-build --release"


### PR DESCRIPTION
After upgrading to a newer version of cloudflare workers, download speeds can be improved tenfold